### PR TITLE
fix(sed): CVE-2026-5958

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+sed (4.9-2deepin2) unstable; urgency=medium
+
+  * Fix CVE-2026-5958: TOCTOU race in sed -i --follow-symlinks
+    (upstream commit 6b9b43c55ccd3beadbc0094b983c82bdb389f33b)
+
+ -- deepin-ci-robot <packages@deepin.org>  Thu, 04 Jun 2026 09:00:00 +0800
+
 sed (4.9-2deepin1) unstable; urgency=medium
 
   * feat: add sw64 support.

--- a/debian/patches/CVE-2026-5958.patch
+++ b/debian/patches/CVE-2026-5958.patch
@@ -1,0 +1,13 @@
+Index: sed/sed/execute.c
+===================================================================
+--- sed.orig/sed/execute.c
++++ sed/sed/execute.c
+@@ -559,7 +559,7 @@ open_next_file (const char *name, struct
+       if (follow_symlinks)
+         input->in_file_name = follow_symlink (name);
+ 
+-      if ( ! (input->fp = ck_fopen (name, read_mode, false)) )
++      if ( ! (input->fp = ck_fopen (input->in_file_name, read_mode, false)) )
+         {
+           const char *ptr = strerror (errno);
+           fprintf (stderr, _("%s: can't read %s: %s\n"), program_name,

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 0001-feat-add-sw64-support.patch
+CVE-2026-5958.patch


### PR DESCRIPTION
Fix TOCTOU race in sed -i --follow-symlinks.

Upstream: https://git.savannah.gnu.org/cgit/sed.git/commit/?id=6b9b43c55ccd3beadbc0094b983c82bdb389f33b

Co-Authored-By: hudeng <hudeng@deepin.org>

Fix-Approach: patch
Generated-By: deepseek-v4-flash